### PR TITLE
Implement basic Vault::Generic::Secret pseudo parameter handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,21 +120,28 @@ Will result in a template with the following parameter defined:
 }
 ~~~
 
-And the value of this parameter will be stored and retrieved from a Vault key by default named:
+And the value of this parameter will be stored and retrieved from a stack
+specific Vault key by default named like:
 
 ~~~
-cubbyhole/
+cubbyhole/SparkleFormation/template/SecretValue
 ~~~
+
+In this example the template is named 'template', but this will be replaced with
+the stack name during create/update operations.
 
 The value will be stored in vault and retrieved dynamically at stack creation
 time. If the `sfn` command is running in a CI environment, where the `CI`
 environment variable is set, then the callback will attempt to use the default
-generic secret backed path in a stack specific location.
+generic secret backed path of `secret` in a stack specific location.
 
 For local development needs or if this environment variable is undetected the
 vault cubbyhole is used.
 
-The path is configurable by using the `:pseudo_parameter_path` in the sfn config:
+The base path is also configurable by using the `:pseudo_parameter_path` in the
+sfn config. This replaces either `cubbyhole` or `secret` in the vault key used
+to store the parameter values. If configured this base path will override any CI
+environment detection and always be honored.
 
 ~~~ruby
 ...
@@ -146,6 +153,20 @@ end
 By default 15 character base64 strings are generated using SecureRandom. The
 length can be adjusted by setting `:pseudo_parameter_length` in the config to
 any integer value.
+
+# Known Issues
+
+If the iam_delay for the vault read behavior is not long enough the generated
+credentials will not be available for use and api requests will fail. As noted
+in
+the
+[Vault documentation](https://www.vaultproject.io/docs/secrets/aws/index.html#dynamic-iam-users) this
+is a limitation due to the eventually consistent behavior of IAM credentials. If
+you need the credentials to be immediately available, it is suggested to use
+the
+[STS Callback](http://www.sparkleformation.io/docs/sfn/callbacks.html#aws-assume-role) and
+set thestatus to `disabled` in the vault config section. This will disable the
+vault read behavior but still handles pseudo parameters.
 
 # Info
 

--- a/lib/sfn-vault.rb
+++ b/lib/sfn-vault.rb
@@ -5,8 +5,9 @@ module SfnVault
   autoload :Platform, 'sfn-vault/platform'
   autoload :Windows, 'sfn-vault/windows'
   autoload :CertificateStore, 'sfn-vault/certificate_store'
+  autoload :Utils, 'sfn-vault/utils'
 end
 
 require 'sfn-vault/version'
 require 'sfn-vault/callback'
-
+require 'sfn-vault/inject'

--- a/lib/sfn-vault/callback.rb
+++ b/lib/sfn-vault/callback.rb
@@ -53,7 +53,7 @@ module Sfn
       end
 
       # Build the path where generated secrets can be saved in Vault
-      # This will use the value of `:parameter_path` from the config if set. If
+      # This will use the value of `:pseudo_parameter_path` from the config if set. If
       # unset it will attempt to build a type of standardized path based on the
       # combined value any stack 'Project' tag and Stack name.
       # Project will fallback to 'SparkleFormation' if unset

--- a/lib/sfn-vault/callback.rb
+++ b/lib/sfn-vault/callback.rb
@@ -62,7 +62,7 @@ module Sfn
       # @param parameter [String] Template parameter to save value for in vault
       # @return [String] String value or stack name if available or default to template name
       def vault_path_name(args, parameter)
-        return config.fetch(:vault, :pseudo_parameter_path, nil) if config.fetch(:vault, :pseudo_parameter_path, nil)
+        return config.get(:vault, :pseudo_parameter_path) if config.get(:vault, :pseudo_parameter_path)
         # If we have a stack name use it, otherwise try to get from env and fallback to just template name
         stack_name = args.first[:stack_name].nil? ? ENV.fetch('STACK_NAME', stack.name).to_s : args.first[:stack_name]
         project = config[:options][:tags].fetch('Project', 'SparkleFormation')

--- a/lib/sfn-vault/callback.rb
+++ b/lib/sfn-vault/callback.rb
@@ -64,6 +64,7 @@ module Sfn
       def vault_path_name(args, parameter)
         return config.get(:vault, :pseudo_parameter_path) if config.get(:vault, :pseudo_parameter_path)
         # If we have a stack name use it, otherwise try to get from env and fallback to just template name
+        stack = args.first[:sparkle_stack]
         stack_name = args.first[:stack_name].nil? ? ENV.fetch('STACK_NAME', stack.name).to_s : args.first[:stack_name]
         project = config[:options][:tags].fetch('Project', 'SparkleFormation')
 

--- a/lib/sfn-vault/callback.rb
+++ b/lib/sfn-vault/callback.rb
@@ -25,12 +25,12 @@ module Sfn
         config[:parameters] ||= Smash.new
         stack = args.first[:sparkle_stack]
         # 2. find names for things you want,
+        client = vault_client
         pseudo_parameters(stack).each do |param|
           param_path = vault_path_name(args, param)
           ui.debug "Using #{param_path} for saved parameter"
           # check if already saved in vault
           # Save the secret unless one already exists at the defined path
-          client = vault_client
           unless client.logical.read(param_path)
             ui.info "Vault: No pre-existing value for parameter #{param} saving new secret"
             client.logical.write(param_path, value: random_secret)
@@ -79,7 +79,6 @@ module Sfn
                        # or for local dev use cubbyhole
                        File.join(base, project, stack_name, parameter)
                      end
-        ui.debug "Vault: generated parameter value will be stored at #{vault_path}"
         vault_path
       end
 

--- a/lib/sfn-vault/callback.rb
+++ b/lib/sfn-vault/callback.rb
@@ -62,7 +62,8 @@ module Sfn
       # @param parameter [String] Template parameter to save value for in vault
       # @return [String] String value or stack name if available or default to template name
       def vault_path_name(args, parameter)
-        return config.get(:vault, :pseudo_parameter_path) if config.get(:vault, :pseudo_parameter_path)
+        pref = config.get(:vault, :pseudo_parameter_path)
+        base = pref.nil? ?  "secret" : pref
         # If we have a stack name use it, otherwise try to get from env and fallback to just template name
         stack = args.first[:sparkle_stack]
         stack_name = args.first[:stack_name].nil? ? ENV.fetch('STACK_NAME', stack.name).to_s : args.first[:stack_name]
@@ -71,7 +72,7 @@ module Sfn
         # When running in a detectable CI environment assume that we have rights to save a generic secret
         vault_path = if ci_environment?
                        #  write to vault at generic path
-                       "/secret/#{project}/#{stack_name}/#{parameter}"
+                       "/#{base}/#{project}/#{stack_name}/#{parameter}"
                      else
                        # or for local dev use /cubbyhole/Parameter
                        "/cubbyhole/#{parameter}"

--- a/lib/sfn-vault/inject.rb
+++ b/lib/sfn-vault/inject.rb
@@ -2,31 +2,17 @@ class SparkleFormation
   module SparkleAttribute
     module Aws
 
-      require 'vault'
-      require 'securerandom'
-
-      # Polluting SparkleFormation::SparkleAttribute::Aws namespace ?
-      include SfnVault::Utils
-
-      # example usage: vault_parameter!(:masterpassword)
-      def _vault_parameter(*vp_args)
-        vp_name, vp_opts = vp_args
+      # A small helper method for adding the specific named
+      # parameter struct with the custom type
+      def _vault_parameter(vp_name)
         __t_stringish(vp_name)
-        if vp_opts
-          vp_path = vp_opts[:path] if vp_opts[:path]
-        end
-        parameters.set!("vault_parameter_#{vp_name}") do
+        parameters.set!(vp_name) do
           no_echo true
-          description "Automatically generated Vault param #{vp_name}"
-          type 'String'
+          description "Generated secret automatically stored in Vault"
+          type 'Vault::Generic::Secret'
         end
       end
       alias_method :vault_parameter!, :_vault_parameter
     end
   end
 end
-
-# do stuff
-# save to vault cubbyhole/name, ex: cubbyhole/masterpassword
-# generate parameter json with NoEcho true
-# inject parameter value, see sfn-parameters

--- a/lib/sfn-vault/inject.rb
+++ b/lib/sfn-vault/inject.rb
@@ -1,0 +1,32 @@
+class SparkleFormation
+  module SparkleAttribute
+    module Aws
+
+      require 'vault'
+      require 'securerandom'
+
+      # Polluting SparkleFormation::SparkleAttribute::Aws namespace ?
+      include SfnVault::Utils
+
+      # example usage: vault_parameter!(:masterpassword)
+      def _vault_parameter(*vp_args)
+        vp_name, vp_opts = vp_args
+        __t_stringish(vp_name)
+        if vp_opts
+          vp_path = vp_opts[:path] if vp_opts[:path]
+        end
+        parameters.set!("vault_parameter_#{vp_name}") do
+          no_echo true
+          description "Automatically generated Vault param #{vp_name}"
+          type 'String'
+        end
+      end
+      alias_method :vault_parameter!, :_vault_parameter
+    end
+  end
+end
+
+# do stuff
+# save to vault cubbyhole/name, ex: cubbyhole/masterpassword
+# generate parameter json with NoEcho true
+# inject parameter value, see sfn-parameters

--- a/sfn-vault.gemspec
+++ b/sfn-vault.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.license = 'Apache-2.0'
   s.require_path = 'lib'
   s.add_dependency 'sfn', '>= 3.0', '< 4.0'
-  s.add_dependency 'vault', '~> 0.7.3'
+  s.add_dependency 'vault', '~> 0.9.0'
   s.add_dependency 'ffi', '~> 1.9.14'
   s.add_development_dependency 'pry', '~> 0.10.4'
   s.add_development_dependency 'pry-byebug', '~> 3.4', '>= 3.4.2'


### PR DESCRIPTION
A working method to get/set secrets from a configured Vault instance.

This callback looks up all parameters of the defined type then reads the value for that Parameter from Vault or generates a value if none exists. Then modifies the parameters type to a 'String' value supported by AWS and uses the value during create.